### PR TITLE
Feature/u camp 2012

### DIFF
--- a/app/Http/Controllers/Api/ContributionController.php
+++ b/app/Http/Controllers/Api/ContributionController.php
@@ -65,7 +65,25 @@ class ContributionController extends Controller
 
     public function destroy(int $id)
     {
-        $this->contributionService->delete($id);
-        return $this->response(null, 'Contribution deleted successfully');
+        try {
+            $this->contributionService->delete($id);
+            return $this->response(null, 'Contribution deleted successfully');
+        } catch (\Exception $e) {
+            if ($e->getMessage() === 'Unauthorized to delete this contribution') {
+                return response()->json([
+                    'message' => 'You are not authorized to delete this contribution'
+                ], 403);
+            }
+
+            if ($e->getMessage() === 'Contribution not found') {
+                return response()->json([
+                    'message' => 'Contribution not found'
+                ], 404);
+            }
+
+            return response()->json([
+                'message' => 'An error occurred while deleting the contribution'
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/Api/ContributionController.php
+++ b/app/Http/Controllers/Api/ContributionController.php
@@ -56,11 +56,30 @@ class ContributionController extends Controller
 
     public function update(UpdateContributionRequest $request, int $id)
     {
-        $data = $request->validated();
-        $data['id'] = $id;
-        $contribution = $this->contributionService->update($data);
-        $resource = new ContributionResource($contribution);
-        return $this->response($resource, 'Contribution updated successfully');
+        try {
+            $data = $request->validated();
+            $data['id'] = $id;
+            $data['user_id'] = Auth::user()->id;
+            $contribution = $this->contributionService->update($data);
+            $resource = new ContributionResource($contribution);
+            return $this->response($resource, 'Contribution updated successfully');
+        } catch (\Exception $e) {
+            if ($e->getMessage() === 'Unauthorized to update this contribution') {
+                return response()->json([
+                    'message' => 'You are not authorized to update this contribution'
+                ], 403);
+            }
+
+            if ($e->getMessage() === 'Contribution not found') {
+                return response()->json([
+                    'message' => 'Contribution not found'
+                ], 404);
+            }
+
+            return response()->json([
+                'message' => 'An error occurred while updating the contribution'
+            ], 500);
+        }
     }
 
     public function destroy(int $id)

--- a/app/Http/Controllers/Api/ContributionController.php
+++ b/app/Http/Controllers/Api/ContributionController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\ContributionController\InterestRequest;
 use App\Http\Requests\ContributionController\ShowRequest;
 use App\Http\Resources\ContributionResource;
 use App\Http\Requests\Api\UpdateContributionRequest;
+use App\Http\Requests\Api\DeleteContributionRequest;
 use App\Services\ContributionServiceInterface;
 use Illuminate\Support\Facades\Auth;
 
@@ -56,53 +57,17 @@ class ContributionController extends Controller
 
     public function update(UpdateContributionRequest $request, int $id)
     {
-        try {
-            $data = $request->validated();
-            $data['id'] = $id;
-            $data['user_id'] = Auth::user()->id;
-            $contribution = $this->contributionService->update($data);
-            $resource = new ContributionResource($contribution);
-            return $this->response($resource, 'Contribution updated successfully');
-        } catch (\Exception $e) {
-            if ($e->getMessage() === 'Unauthorized to update this contribution') {
-                return response()->json([
-                    'message' => 'You are not authorized to update this contribution'
-                ], 403);
-            }
-
-            if ($e->getMessage() === 'Contribution not found') {
-                return response()->json([
-                    'message' => 'Contribution not found'
-                ], 404);
-            }
-
-            return response()->json([
-                'message' => 'An error occurred while updating the contribution'
-            ], 500);
-        }
+        $data = $request->validated();
+        $data['id'] = $id;
+        $data['user_id'] = Auth::user()->id;
+        $contribution = $this->contributionService->update($data);
+        $resource = new ContributionResource($contribution);
+        return $this->response($resource, 'Contribution updated successfully');
     }
 
-    public function destroy(int $id)
+    public function destroy(DeleteContributionRequest $request, int $id)
     {
-        try {
-            $this->contributionService->delete($id);
-            return $this->response(null, 'Contribution deleted successfully');
-        } catch (\Exception $e) {
-            if ($e->getMessage() === 'Unauthorized to delete this contribution') {
-                return response()->json([
-                    'message' => 'You are not authorized to delete this contribution'
-                ], 403);
-            }
-
-            if ($e->getMessage() === 'Contribution not found') {
-                return response()->json([
-                    'message' => 'Contribution not found'
-                ], 404);
-            }
-
-            return response()->json([
-                'message' => 'An error occurred while deleting the contribution'
-            ], 500);
-        }
+        $this->contributionService->delete($id);
+        return $this->response(null, 'Contribution deleted successfully');
     }
 }

--- a/app/Http/Controllers/Api/ContributionController.php
+++ b/app/Http/Controllers/Api/ContributionController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\ContributionController\CreateRequest;
 use App\Http\Requests\ContributionController\InterestRequest;
 use App\Http\Requests\ContributionController\ShowRequest;
 use App\Http\Resources\ContributionResource;
+use App\Http\Requests\Api\UpdateContributionRequest;
 use App\Services\ContributionServiceInterface;
 use Illuminate\Support\Facades\Auth;
 
@@ -51,5 +52,20 @@ class ContributionController extends Controller
         $data['user_id'] = Auth::user()->id;
         $result = $this->contributionService->interested($data);
         return $this->response($result, $result['message']);
+    }
+
+    public function update(UpdateContributionRequest $request, int $id)
+    {
+        $data = $request->validated();
+        $data['id'] = $id;
+        $contribution = $this->contributionService->update($data);
+        $resource = new ContributionResource($contribution);
+        return $this->response($resource, 'Contribution updated successfully');
+    }
+
+    public function destroy(int $id)
+    {
+        $this->contributionService->delete($id);
+        return $this->response(null, 'Contribution deleted successfully');
     }
 }

--- a/app/Http/Requests/Api/DeleteContributionRequest.php
+++ b/app/Http/Requests/Api/DeleteContributionRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteContributionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'id' => 'required|exists:contributions,id'
+        ];
+    }
+}

--- a/app/Http/Requests/Api/DeleteContributionRequest.php
+++ b/app/Http/Requests/Api/DeleteContributionRequest.php
@@ -2,19 +2,50 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Models\Contribution;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class DeleteContributionRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return true;
+        $contributionId = $this->route('id');
+        $contribution = Contribution::find($contributionId);
+
+        if (!$contribution) {
+            return false;
+        }
+
+        return $contribution->user_id === Auth::id();
     }
 
     public function rules(): array
     {
-        return [
-            'id' => 'required|exists:contributions,id'
-        ];
+        return [];
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     */
+    protected function failedAuthorization()
+    {
+        $contributionId = $this->route('id');
+        $contribution = Contribution::find($contributionId);
+
+        if (!$contribution) {
+            throw new HttpResponseException(
+                response()->json([
+                    'message' => 'Contribution not found'
+                ], 404)
+            );
+        }
+
+        throw new HttpResponseException(
+            response()->json([
+                'message' => 'You are not authorized to delete this contribution'
+            ], 403)
+        );
     }
 }

--- a/app/Http/Requests/Api/UpdateContributionRequest.php
+++ b/app/Http/Requests/Api/UpdateContributionRequest.php
@@ -2,13 +2,43 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Models\Contribution;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class UpdateContributionRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return true;
+        $contributionId = $this->route('id');
+        $contribution = Contribution::find($contributionId);
+
+        if (!$contribution) {
+            return false;
+        }
+
+        return $contribution->user_id === Auth::id();
+    }
+
+    protected function failedAuthorization()
+    {
+        $contributionId = $this->route('id');
+        $contribution = Contribution::find($contributionId);
+
+        if (!$contribution) {
+            throw new HttpResponseException(
+                response()->json([
+                    'message' => 'Contribution not found'
+                ], 404)
+            );
+        }
+
+        throw new HttpResponseException(
+            response()->json([
+                'message' => 'You are not authorized to update this contribution'
+            ], 403)
+        );
     }
 
     public function rules(): array

--- a/app/Http/Requests/Api/UpdateContributionRequest.php
+++ b/app/Http/Requests/Api/UpdateContributionRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateContributionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|min:8',
+            'content' => 'required',
+            'type' => 'required|in:idea,question,guide,research,project',
+            'allow_collab' => 'boolean',
+            'is_public' => 'boolean',
+            'status' => 'required|in:draft,active,completed',
+            'thumbnail_url' => 'nullable|image|mimes:png,jpg,jpeg,webp|max:2048',
+            'attachments' => 'nullable|array',
+            'attachments.*' => 'nullable|file|mimes:png,jpg,jpeg,webp,pdf,xls,xlsx|max:2048',
+            'tags' => 'nullable|array',
+            'tags.*' => 'required|string'
+        ];
+    }
+}

--- a/app/Models/Contribution.php
+++ b/app/Models/Contribution.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Contribution extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
     protected $fillable = [
         'user_id',
         'title',

--- a/app/Repositories/ContributionRepository.php
+++ b/app/Repositories/ContributionRepository.php
@@ -29,4 +29,23 @@ class ContributionRepository implements ContributionRepositoryInterface
     {
         return Contribution::create($data);
     }
+
+    public function update(int $id, array $data = [])
+    {
+        $contribution = $this->find($id);
+        if (!$contribution) {
+            throw new \Exception('Contribution not found');
+        }
+        $contribution->update($data);
+        return $contribution;
+    }
+
+    public function delete(int $id)
+    {
+        $contribution = $this->find($id);
+        if (!$contribution) {
+            throw new \Exception('Contribution not found');
+        }
+        return $contribution->delete();
+    }
 }

--- a/app/Repositories/ContributionRepository.php
+++ b/app/Repositories/ContributionRepository.php
@@ -33,9 +33,6 @@ class ContributionRepository implements ContributionRepositoryInterface
     public function update(int $id, array $data = [])
     {
         $contribution = $this->find($id);
-        if (!$contribution) {
-            throw new \Exception('Contribution not found');
-        }
         $contribution->update($data);
         return $contribution;
     }
@@ -43,9 +40,6 @@ class ContributionRepository implements ContributionRepositoryInterface
     public function delete(int $id)
     {
         $contribution = $this->find($id);
-        if (!$contribution) {
-            throw new \Exception('Contribution not found');
-        }
         return $contribution->delete();
     }
 }

--- a/app/Repositories/ContributionRepositoryInterface.php
+++ b/app/Repositories/ContributionRepositoryInterface.php
@@ -9,4 +9,6 @@ interface ContributionRepositoryInterface
     public function list(array $filters = []);
     public function create(array $data = []);
     public function find(int $id);
+    public function update(int $id, array $data = []);
+    public function delete(int $id);
 }

--- a/app/Services/ContributionService.php
+++ b/app/Services/ContributionService.php
@@ -40,25 +40,35 @@ class ContributionService implements ContributionServiceInterface
         try {
             $id = $data['id'];
             unset($data['id']);
+            
+            // Find the contribution first
+            $contribution = $this->contributionRepository->find($id);
+            
+            if (!$contribution) {
+                throw new \Exception('Contribution not found');
+            }
 
+            // Check if the authenticated user owns this contribution
+            if ($contribution->user_id !== $data['user_id']) {
+                throw new \Exception('Unauthorized to update this contribution');
+            }
+            
             if (isset($data['content'])) {
                 $data['content'] = json_encode($data['content']);
             }
-
+            
             $contribution = $this->contributionRepository->update($id, $data);
-
+            
             if (isset($data['tags'])) {
                 $tagIds = $this->tagRepository->createMany($data['tags']);
                 $contribution->tags()->sync($tagIds);
             }
-
+            
             return $contribution;
         } catch (\Exception $e) {
             throw new \Exception($e->getMessage());
         }
-    }
-
-    public function delete(int $id)
+    }    public function delete(int $id)
     {
         try {
             $contribution = $this->contributionRepository->find($id);

--- a/app/Services/ContributionService.php
+++ b/app/Services/ContributionService.php
@@ -61,6 +61,17 @@ class ContributionService implements ContributionServiceInterface
     public function delete(int $id)
     {
         try {
+            $contribution = $this->contributionRepository->find($id);
+            
+            if (!$contribution) {
+                throw new \Exception('Contribution not found');
+            }
+
+            // Check if the authenticated user owns this contribution
+            if ($contribution->user_id !== auth()->id()) {
+                throw new \Exception('Unauthorized to delete this contribution');
+            }
+
             return $this->contributionRepository->delete($id);
         } catch (\Exception $e) {
             throw new \Exception($e->getMessage());

--- a/app/Services/ContributionService.php
+++ b/app/Services/ContributionService.php
@@ -35,6 +35,38 @@ class ContributionService implements ContributionServiceInterface
         }
     }
 
+    public function update(array $data = [])
+    {
+        try {
+            $id = $data['id'];
+            unset($data['id']);
+
+            if (isset($data['content'])) {
+                $data['content'] = json_encode($data['content']);
+            }
+
+            $contribution = $this->contributionRepository->update($id, $data);
+
+            if (isset($data['tags'])) {
+                $tagIds = $this->tagRepository->createMany($data['tags']);
+                $contribution->tags()->sync($tagIds);
+            }
+
+            return $contribution;
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+    }
+
+    public function delete(int $id)
+    {
+        try {
+            return $this->contributionRepository->delete($id);
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+    }
+
     public function interested(array $data = [])
     {
         try {

--- a/app/Services/ContributionService.php
+++ b/app/Services/ContributionService.php
@@ -40,30 +40,18 @@ class ContributionService implements ContributionServiceInterface
         try {
             $id = $data['id'];
             unset($data['id']);
-            
-            // Find the contribution first
-            $contribution = $this->contributionRepository->find($id);
-            
-            if (!$contribution) {
-                throw new \Exception('Contribution not found');
-            }
 
-            // Check if the authenticated user owns this contribution
-            if ($contribution->user_id !== $data['user_id']) {
-                throw new \Exception('Unauthorized to update this contribution');
-            }
-            
             if (isset($data['content'])) {
                 $data['content'] = json_encode($data['content']);
             }
-            
+
             $contribution = $this->contributionRepository->update($id, $data);
-            
+
             if (isset($data['tags'])) {
                 $tagIds = $this->tagRepository->createMany($data['tags']);
                 $contribution->tags()->sync($tagIds);
             }
-            
+
             return $contribution;
         } catch (\Exception $e) {
             throw new \Exception($e->getMessage());
@@ -71,17 +59,6 @@ class ContributionService implements ContributionServiceInterface
     }    public function delete(int $id)
     {
         try {
-            $contribution = $this->contributionRepository->find($id);
-            
-            if (!$contribution) {
-                throw new \Exception('Contribution not found');
-            }
-
-            // Check if the authenticated user owns this contribution
-            if ($contribution->user_id !== auth()->id()) {
-                throw new \Exception('Unauthorized to delete this contribution');
-            }
-
             return $this->contributionRepository->delete($id);
         } catch (\Exception $e) {
             throw new \Exception($e->getMessage());

--- a/app/Services/ContributionServiceInterface.php
+++ b/app/Services/ContributionServiceInterface.php
@@ -8,4 +8,6 @@ interface ContributionServiceInterface
     public function create(array $data = []);
     public function interested(array $data = []);
     public function find(int $id);
+    public function update(array $data = []);
+    public function delete(int $id);
 }

--- a/database/migrations/2025_08_12_000001_add_soft_deletes_to_contributions_table.php
+++ b/database/migrations/2025_08_12_000001_add_soft_deletes_to_contributions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('contributions', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('contributions', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};


### PR DESCRIPTION
## 📌 What does this PR do?

Added update and delete functionality to the Contribution API with proper authorization and validation.

---

## 📝 Changes made

- [x] Added Update Contribution endpoint with validation
- [x] Added Delete (soft delete) Contribution endpoint with authorization
- [x] Added error handling for unauthorized deletion attempts
- [x] Implemented soft deletes for Contributions
- [x] Added migration for soft deletes

---

## ✅ How to test

### Update Contribution:
1. Open Postman
2. Send PUT request to `http://localhost/api/contributions/{id}`
3. Set headers:
   ```
   Authorization: Bearer {your_token}
   Accept: application/json
   Content-Type: application/json
   ```
4. Add body:
   ```json
   {
     "title": "Updated Title Example",
     "content": "Updated content example",
     "type": "idea",
     "allow_collab": true,
     "is_public": true,
     "status": "active"
   }
   ```
5. Expected response (200 OK):
   ```json
   {
     "message": "Contribution updated successfully",
     "data": {
       // updated contribution data
     }
   }
   ```

### Delete Contribution:
1. Open Postman
2. Send DELETE request to `http://localhost/api/contributions/{id}`
3. Set headers:
   ```
   Authorization: Bearer {your_token}
   Accept: application/json
   ```
4. Test scenarios:
   - Delete own contribution → Success (200 OK)
   - Delete other's contribution → Forbidden (403)
   - Delete non-existent contribution → Not Found (404)

### Verify Soft Delete:
1. Check database after deletion
2. Record should still exist with `deleted_at` timestamp
3. Run query:
   ```sql
   SELECT * FROM contributions WHERE id = {deleted_id};
   ```

---

## 📸 Screenshots (if UI changes)

N/A - API changes only

---

## 📎 Related Issues / Tickets

- Implement CRUD operations for Contributions
- Add authorization for contribution management