### PR TITLE
feature backend:Contribution Bookmark Api

### DIFF
--- a/app/Http/Controllers/Api/BookmarkController.php
+++ b/app/Http/Controllers/Api/BookmarkController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ContributionController\BookmarkRequest;
+use App\Http\Requests\ContributionController\BookmarkListRequest;
+use App\Http\Resources\ContributionResource;
+use App\Services\ContributionServiceInterface;
+use Illuminate\Support\Facades\Auth;
+
+class BookmarkController extends Controller
+{
+    public function __construct(private ContributionServiceInterface $contributionService) {}
+
+    public function store(int $id, BookmarkRequest $request)
+    {
+        $data = $request->validated();
+        $userId = Auth::user()->id;
+        $this->contributionService->bookmark($userId, $data['contribution_id']);
+        return $this->response(null, 'Contribution Bookmark successfully');
+    }
+
+    public function destroy(int $id, BookmarkRequest $request)
+    {
+        $data = $request->validated();
+        $userId = Auth::user()->id;
+        $this->contributionService->unbookmark($userId, $data['contribution_id']);
+        return $this->response(null, 'Contribution Bookmark Removed Successfully');
+    }
+
+    public function index(BookmarkListRequest $request)
+    {
+        $data = $request->validated();
+        $userId = Auth::user()->id;
+        $list = $this->contributionService->listBookmarks($userId, $data['type'] ?? null, $data['per_page'], $data['page']);
+        $resource = ContributionResource::collection($list);
+        return $this->response($resource, "User's bookmarks retrieved successfully.");
+    }
+}
+
+

--- a/app/Http/Requests/ContributionController/BookmarkListRequest.php
+++ b/app/Http/Requests/ContributionController/BookmarkListRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests\ContributionController;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+class BookmarkListRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'per_page' => $this->input('per_page', 10),
+            'page' => $this->input('page', 1),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'type' => ['nullable', 'in:idea,question,guide,research,project'],
+            'per_page' => ['nullable', 'integer', 'min:1'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $user = Auth::user();
+            if (!$user) {
+                return;
+            }
+
+            $query = $user->bookmarkedContributions();
+            $type = $this->input('type');
+            if ($type) {
+                $query->where('type', $type);
+            }
+
+            $exists = $query->exists();
+            if (!$exists) {
+                $validator->errors()->add('bookmarks', 'No bookmarks found for the given criteria.');
+            }
+        });
+    }
+}
+
+

--- a/app/Http/Requests/ContributionController/BookmarkRequest.php
+++ b/app/Http/Requests/ContributionController/BookmarkRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\ContributionController;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+
+class BookmarkRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'contribution_id' => $this->route('id'),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'contribution_id' => ['required', 'integer', 'exists:contributions,id'],
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $user = Auth::user();
+            if (!$user) {
+                return;
+            }
+
+            $contributionId = (int) $this->input('contribution_id');
+
+            $hasBookmark = $user->bookmarkedContributions()
+                ->where('contribution_id', $contributionId)
+                ->exists();
+
+            if ($this->isMethod('post') && $hasBookmark) {
+                $validator->errors()->add('contribution_id', 'Contribution already bookmarked.');
+            }
+
+            if ($this->isMethod('delete') && !$hasBookmark) {
+                $validator->errors()->add('contribution_id', 'Bookmark does not exist.');
+            }
+        });
+    }
+}
+
+

--- a/app/Models/Contribution.php
+++ b/app/Models/Contribution.php
@@ -55,4 +55,10 @@ class Contribution extends Model
     {
         return $this->interests->count();
     }
+
+    public function bookmarkedBy()
+    {
+        return $this->belongsToMany(User::class, 'contribution_bookmarks', 'contribution_id', 'user_id')
+            ->withTimestamps();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,4 +52,10 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function bookmarkedContributions()
+    {
+        return $this->belongsToMany(Contribution::class, 'contribution_bookmarks', 'user_id', 'contribution_id')
+            ->withTimestamps();
+    }
 }

--- a/app/Repositories/ContributionRepositoryInterface.php
+++ b/app/Repositories/ContributionRepositoryInterface.php
@@ -12,4 +12,7 @@ interface ContributionRepositoryInterface
     public function findById(int $id): ?array;
     public function update(int $id, array $data = []);
     public function delete(int $id);
+    public function addBookmark(int $userId, int $contributionId): void;
+    public function removeBookmark(int $userId, int $contributionId): void;
+    public function listBookmarks(int $userId, ?string $type = null, int $perPage = 10, int $page = 1);
 }

--- a/app/Services/ContributionService.php
+++ b/app/Services/ContributionService.php
@@ -117,4 +117,19 @@ class ContributionService implements ContributionServiceInterface
     {
         return $this->contributionRepository->find($id);
     }
+
+    public function bookmark(int $userId, int $contributionId): void
+    {
+        $this->contributionRepository->addBookmark($userId, $contributionId);
+    }
+
+    public function unbookmark(int $userId, int $contributionId): void
+    {
+        $this->contributionRepository->removeBookmark($userId, $contributionId);
+    }
+
+    public function listBookmarks(int $userId, ?string $type = null, int $perPage = 10, int $page = 1)
+    {
+        return $this->contributionRepository->listBookmarks($userId, $type, $perPage, $page);
+    }
 }

--- a/app/Services/ContributionServiceInterface.php
+++ b/app/Services/ContributionServiceInterface.php
@@ -10,4 +10,7 @@ interface ContributionServiceInterface
     public function find(int $id);
     public function update(array $data = []);
     public function delete(int $id);
+    public function bookmark(int $userId, int $contributionId): void;
+    public function unbookmark(int $userId, int $contributionId): void;
+    public function listBookmarks(int $userId, ?string $type = null, int $perPage = 10, int $page = 1);
 }

--- a/database/migrations/2025_09_29_000000_create_contribution_bookmarks_table.php
+++ b/database/migrations/2025_09_29_000000_create_contribution_bookmarks_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('contribution_bookmarks', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('contribution_id');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'contribution_id']);
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('contribution_id')->references('id')->on('contributions')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('contribution_bookmarks');
+    }
+};
+
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\SocialAuthController;
 use App\Http\Controllers\Api\CollaborationController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\ProgressController;
+use App\Http\Controllers\Api\BookmarkController;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Log;
 use App\Models\Notification;
@@ -70,6 +71,12 @@ Route::prefix('contributions')->group(function () {
     Route::put('/{id}', [ContributionController::class, 'update'])->middleware('auth:sanctum');
     Route::delete('/{id}', [ContributionController::class, 'destroy'])->middleware('auth:sanctum');
     Route::post('/{id}/interest', [ContributionController::class, 'interest'])->middleware('auth:sanctum');
+});
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('contribution/{id}/bookmarks', [BookmarkController::class, 'store']);
+    Route::delete('contribution/{id}/bookmarks', [BookmarkController::class, 'destroy']);
+    Route::get('contribution/bookmarks', [BookmarkController::class, 'index']);
 });
 
 // Project Collaboration Routes


### PR DESCRIPTION
### 📌 What does this PR do?

Adds Contribution Bookmark feature using existing repository/service/request pattern:
- Users can bookmark/unbookmark a contribution.
- Users can retrieve their bookmarks (optionally filtered by type).
- Request-level validations for add/remove/list actions.

---

### 📝 Changes made

- [x] Added `contribution_bookmarks` pivot migration with FKs and unique constraint.
- [x] Added relations:
  - `User::bookmarkedContributions()`
  - `Contribution::bookmarkedBy()`
- [x] Extended `ContributionRepository(Interface)` with:
  - `addBookmark`, `removeBookmark`, `listBookmarks`
- [x] Extended `ContributionService(Interface)` with:
  - `bookmark`, `unbookmark`, `listBookmarks`
- [x] Added requests:
  - `BookmarkRequest`: validates route `{id}`; prevents duplicate add and invalid delete
  - `BookmarkListRequest`: validates params; optional `type`; returns 422 if no bookmarks
- [x] Controller:
  - `BookmarkController` using `ContributionServiceInterface` (store/destroy/index)
- [x] Routes:
  - `POST api/contribution/{id}/bookmarks`
  - `DELETE api/contribution/{id}/bookmarks`
  - `GET api/contribution/bookmarks`
- [x] Response shape uses existing `ContributionResource`.

---

### ✅ How to test

Prereqs:
- php artisan migrate
- Base URL: `http://localhost/api`
- Auth with Sanctum Bearer token.

1) Login to get token  
- POST `auth/login`  
Body:
```json
{"email":"you@example.com","password":"your-password"}
```
Set `Authorization: Bearer <TOKEN>` for the next requests.

2) (Optional) Create a contribution  
- POST `contributions`  
Body:
```json
{
  "title": "My idea",
  "content": {"blocks":[{"type":"paragraph","data":{"text":"Hello"}}]},
  "type": "idea",
  "allow_collab": true,
  "is_public": true,
  "status": "active",
  "tags": ["tag1","tag2"]
}
```
Copy returned `id`.

3) Add bookmark  
- POST `contribution/{id}/bookmarks`  
Headers: `Authorization: Bearer <TOKEN>`  
Expected: 200, message “Contribution Bookmark successfully”.

4) List bookmarks  
- GET `contribution/bookmarks?type=idea&per_page=10&page=1`  
- Omit `type` to fetch all.  
If none match, returns 422 with “No bookmarks found for the given criteria.”  
Expected 200 with paginated `ContributionResource` items when present.

5) Remove bookmark  
- DELETE `contribution/{id}/bookmarks`  
- If not bookmarked, returns 422 “Bookmark does not exist.”  
Expected: 200, message “Contribution Bookmark Removed Successfully”.

Validation behaviors:
- POST same bookmark twice → 422 “Contribution already bookmarked.”
- DELETE non-existent bookmark → 422 “Bookmark does not exist.”
- GET with no bookmarks (or filtered out by `type`) → 422 “No bookmarks found…”

---

### 📸 Screenshots (if UI changes)

N/A (backend API)

---
